### PR TITLE
Add simple inventory system

### DIFF
--- a/gmaddon/lua/modules/inventory/cl_inventory.lua
+++ b/gmaddon/lua/modules/inventory/cl_inventory.lua
@@ -1,0 +1,53 @@
+include("modules/inventory/sh_inventory.lua")
+
+local inventory = {}
+
+local function openInventory()
+    if IsValid(inventory.Frame) then
+        inventory.Frame:Remove()
+    end
+
+    local frame = vgui.Create("DFrame")
+    frame:SetSize(300, 400)
+    frame:Center()
+    frame:SetTitle("Inventaire")
+    frame:MakePopup()
+    inventory.Frame = frame
+
+    local model = vgui.Create("DModelPanel", frame)
+    model:SetSize(200, 200)
+    model:SetPos(50, 30)
+    model:SetModel(LocalPlayer():GetModel())
+    model:SetLookAt(Vector(0, 0, 60))
+    model:SetCamPos(Vector(80, 0, 60))
+
+    local list = vgui.Create("DListView", frame)
+    list:SetPos(10, 240)
+    list:SetSize(280, 150)
+    list:AddColumn("Items")
+    for _, c in ipairs(LocalPlayer():GetInventory()) do
+        list:AddLine(c)
+    end
+
+    function frame:OnRemove()
+        inventory.Frame = nil
+    end
+end
+
+net.Receive("Inventory_Update", function()
+    local count = net.ReadUInt(8)
+    LocalPlayer().Inventory = {}
+    for i = 1, count do
+        table.insert(LocalPlayer().Inventory, net.ReadString())
+    end
+end)
+
+hook.Add("PlayerButtonDown", "InventoryToggle", function(ply, key)
+    if key == KEY_I and ply == LocalPlayer() then
+        if inventory.Frame then
+            inventory.Frame:Close()
+        else
+            openInventory()
+        end
+    end
+end)

--- a/gmaddon/lua/modules/inventory/sh_inventory.lua
+++ b/gmaddon/lua/modules/inventory/sh_inventory.lua
@@ -1,0 +1,38 @@
+-- Shared inventory code
+if SERVER then
+    util.AddNetworkString("Inventory_Update")
+end
+
+local PLAYER = FindMetaTable("Player")
+
+function PLAYER:GetInventory()
+    self.Inventory = self.Inventory or {}
+    return self.Inventory
+end
+
+function PLAYER:AddItem(class)
+    local inv = self:GetInventory()
+    table.insert(inv, class)
+    self:SendInventory()
+end
+
+function PLAYER:RemoveItem(index)
+    local inv = self:GetInventory()
+    local class = inv[index]
+    if class then
+        table.remove(inv, index)
+        self:SendInventory()
+    end
+    return class
+end
+
+function PLAYER:SendInventory()
+    if SERVER then
+        net.Start("Inventory_Update")
+        net.WriteUInt(#self:GetInventory(), 8)
+        for _, c in ipairs(self.Inventory) do
+            net.WriteString(c)
+        end
+        net.Send(self)
+    end
+end

--- a/gmaddon/lua/modules/inventory/sv_inventory.lua
+++ b/gmaddon/lua/modules/inventory/sv_inventory.lua
@@ -1,0 +1,41 @@
+AddCSLuaFile()
+include("modules/inventory/sh_inventory.lua")
+
+-- Droppable item entity creation
+local ITEM_MODEL = "models/props_junk/wood_crate001a.mdl"
+
+local function spawnItem(pos, class)
+    local ent = ents.Create("prop_physics")
+    if not IsValid(ent) then return end
+    ent:SetModel(ITEM_MODEL)
+    ent:SetPos(pos)
+    ent:Spawn()
+    ent.IsDroppableItem = true
+    ent.ItemClass = class
+end
+
+hook.Add("PlayerInitialSpawn", "InventoryInit", function(ply)
+    ply.Inventory = {}
+    timer.Simple(1, function()
+        if IsValid(ply) then
+            ply:SendInventory()
+        end
+    end)
+end)
+
+hook.Add("PlayerUse", "InventoryPickup", function(ply, ent)
+    if ent.IsDroppableItem and ply:KeyDown(IN_WALK) then -- Alt + E
+        ply:AddItem(ent.ItemClass or "crate")
+        ent:Remove()
+        return false
+    end
+end)
+
+concommand.Add("gm_dropitem", function(ply, cmd, args)
+    local index = tonumber(args[1] or 1)
+    local class = ply:RemoveItem(index)
+    if class then
+        local pos = ply:GetPos() + ply:GetForward() * 50 + Vector(0, 0, 10)
+        spawnItem(pos, class)
+    end
+end)


### PR DESCRIPTION
## Summary
- add shared inventory helpers and networking
- server-side support for dropping and picking items
- client-side interface bound to `i` with player model preview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de4ae13608324bb31fc044dd5660f